### PR TITLE
Fix for Vertical Scroll based on max-height

### DIFF
--- a/PdfiumViewer/PdfRenderer.cs
+++ b/PdfiumViewer/PdfRenderer.cs
@@ -253,7 +253,7 @@ namespace PdfiumViewer
 
         protected override Rectangle GetDocumentBounds()
         {
-            int height = (int)(_height * _scaleFactor + (ShadeBorder.Size.Vertical + PageMargin.Vertical) * _document.PageCount);
+            int height = (int)(_maxHeight * _document.PageCount * _scaleFactor + (ShadeBorder.Size.Vertical + PageMargin.Vertical) * _document.PageCount); //(int)(_height * _scaleFactor + (ShadeBorder.Size.Vertical + PageMargin.Vertical) * _document.PageCount);
             int width = (int)(_maxWidth * _scaleFactor + ShadeBorder.Size.Horizontal + PageMargin.Horizontal);
             
             var center = new Point(


### PR DESCRIPTION
For the case of different page height in a single pdf, vertical scroll
height should be decided based on the rendered height and not on the
page(actual) height.
For eg:
I had a PDF of let's say 3 pages. First page height is 500 and others height is 600. Max-height is taken for the rendering as 600.
When I am scrolling the PDF file, the last page content is not rendered completely since the scroll height is equal to 500+600+600=1700 and actual rendered height is 1800. 

May be this would act as a fix for issue #9 too. 