### PR TITLE
Don't change Landscape mode when special situation

### DIFF
--- a/PdfiumViewer/PdfPrintDocument.cs
+++ b/PdfiumViewer/PdfPrintDocument.cs
@@ -28,7 +28,8 @@ namespace PdfiumViewer
 
         protected override void OnQueryPageSettings(QueryPageSettingsEventArgs e)
         {
-            if (_currentPage < _document.PageCount)
+            var checkLandscape = (e.PageSettings.Bounds.Width > e.PageSettings.Bounds.Height) == e.PageSettings.Landscape;
+            if (currentPage < document.PageCount && checkLandscape)
                 e.PageSettings.Landscape = GetOrientation(_document.PageSizes[_currentPage]) == Orientation.Landscape;
         }
 


### PR DESCRIPTION
When some printers are lying about landscape mode vs page sizes we don't want to set PageSettings.Landscape. BROTHER QL-570 and BROTHER QL-580 say that PageSettings Width > Height but Landscape is False.
Use your PrintPreview Form and install Brother drivers to check this behaviour.