### PR TITLE
Fix memory corruption

### DIFF
--- a/PdfiumViewer/NativeMethods.Pdfium.cs
+++ b/PdfiumViewer/NativeMethods.Pdfium.cs
@@ -39,7 +39,7 @@ namespace PdfiumViewer
             }
         }
 
-        public static IntPtr FPDF_LoadMemDocument(byte[] data_buf, int size, string password)
+        public static IntPtr FPDF_LoadMemDocument(IntPtr data_buf, int size, string password)
         {
             lock (LockString)
             {
@@ -407,7 +407,7 @@ namespace PdfiumViewer
             public static extern IntPtr FPDF_LoadMemDocument(SafeHandle data_buf, int size, string password);
 
             [DllImport("pdfium.dll", CharSet = CharSet.Ansi)]
-            public static extern IntPtr FPDF_LoadMemDocument(byte[] data_buf, int size, string password);
+            public static extern IntPtr FPDF_LoadMemDocument(IntPtr data_buf, int size, string password);
 
             [DllImport("pdfium.dll")]
             public static extern void FPDF_CloseDocument(IntPtr document);

--- a/PdfiumViewer/PdfBufferFile.cs
+++ b/PdfiumViewer/PdfBufferFile.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Text;
 
 namespace PdfiumViewer
@@ -9,6 +10,7 @@ namespace PdfiumViewer
     {
         private readonly byte[] _buffer;
         private readonly int _length;
+        private IntPtr _copy;
 
         public PdfBufferFile(byte[] buffer)
             : this(buffer, buffer.Length)
@@ -23,7 +25,9 @@ namespace PdfiumViewer
             _buffer = buffer;
             _length = length;
 
-            LoadDocument(NativeMethods.FPDF_LoadMemDocument(_buffer, length, null));
+            _copy = Marshal.AllocHGlobal(buffer.Length);
+            Marshal.Copy(_buffer, 0, _copy, _buffer.Length);
+            LoadDocument(NativeMethods.FPDF_LoadMemDocument(_copy, length, null));
         }
 
         public override void Save(Stream stream)
@@ -32,6 +36,20 @@ namespace PdfiumViewer
                 throw new ArgumentNullException("stream");
 
             stream.Write(_buffer, 0, _length);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+            if (_copy != IntPtr.Zero) {
+                Marshal.FreeHGlobal(_copy);
+                _copy = IntPtr.Zero;
+            }
+        }
+
+        ~PdfBufferFile()
+        {
+            Dispose(true);
         }
     }
 }


### PR DESCRIPTION
If pdf document was passed as buffer pointer to it will be transferred
to pdfium. On GC pass buffer can be moved and pointer became invalid.