### PR TITLE
Added method GetOuterBounds(int page) to return the size of the page

### DIFF
--- a/PdfiumViewer/PdfRenderer.cs
+++ b/PdfiumViewer/PdfRenderer.cs
@@ -81,6 +81,15 @@ namespace PdfiumViewer
             }
         }
 
+        public Rectangle GetOuterBounds(int page)
+        {
+            if (_document == null || !_pageCacheValid)
+                return Rectangle.Empty;
+
+            page = Math.Min(Math.Max(page, 0), _document.PageCount - 1);
+            return _pageCache[page].OuterBounds;
+        }
+
         /// <summary>
         /// Gets or sets the way the document should be zoomed initially.
         /// </summary>
@@ -433,7 +442,7 @@ namespace PdfiumViewer
         {
             int height = (int)(_height * _scaleFactor + (ShadeBorder.Size.Vertical + PageMargin.Vertical) * _document.PageCount);
             int width = (int)(_maxWidth * _scaleFactor + ShadeBorder.Size.Horizontal + PageMargin.Horizontal);
-            
+
             var center = new Point(
                 DisplayRectangle.Width / 2,
                 DisplayRectangle.Height / 2
@@ -442,7 +451,8 @@ namespace PdfiumViewer
             if (
                 DisplayRectangle.Width > ClientSize.Width ||
                 DisplayRectangle.Height > ClientSize.Height
-            ) {
+            )
+            {
                 center.X += DisplayRectangle.Left;
                 center.Y += DisplayRectangle.Top;
             }

--- a/PdfiumViewer/Properties/AssemblyInfo.cs
+++ b/PdfiumViewer/Properties/AssemblyInfo.cs
@@ -15,5 +15,5 @@ using System.Runtime.InteropServices;
 [assembly: CLSCompliant(true)]
 [assembly: Guid("ca63710b-8bc7-4fc5-8c39-210bacf591e8")]
 
-[assembly: AssemblyVersion("2.10.0.0")]
-[assembly: AssemblyFileVersion("2.10.0.0")]
+[assembly: AssemblyVersion("2.10.0.1")]
+[assembly: AssemblyFileVersion("2.10.0.1")]


### PR DESCRIPTION
I needed to get a position on the current page.

``` csharp
private void Renderer_DisplayRectangleChanged(object sender, EventArgs e)
{
    var renderer = _pdfViewer.Renderer;
    var page = renderer.Page;
    var pageCache = renderer.GetOuterBounds(page);

    int x = -renderer.DisplayRectangle.Left + pageCache.Left;
    int y = -renderer.DisplayRectangle.Top - pageCache.Top;

    var rect = new Rectangle(x, y, pageCache.Width, pageCache.Height);
    OnSegmentAndOffsetChanged(page, rect);
}
```
