### PR TITLE
Added LinkClick event to PdfRenderer and PdfViewer

### DIFF
--- a/PdfiumViewer/LinkClickEventHandler.cs
+++ b/PdfiumViewer/LinkClickEventHandler.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Drawing;
+using System.Text;
+using System.Windows.Forms;
+
+namespace PdfiumViewer
+{
+    public class LinkClickEventArgs : HandledEventArgs
+    {
+        /// <summary>
+        /// Gets the link that was clicked.
+        /// </summary>
+        public PdfPageLink Link { get; private set; }
+        
+        public LinkClickEventArgs(PdfPageLink link)
+        {
+            Link = link;
+        }
+    }
+
+    public delegate void LinkClickEventHandler(object sender, LinkClickEventArgs e);
+}

--- a/PdfiumViewer/PdfRenderer.cs
+++ b/PdfiumViewer/PdfRenderer.cs
@@ -530,22 +530,47 @@ namespace PdfiumViewer
 
             if (dx <= SystemInformation.DragSize.Width && dy <= SystemInformation.DragSize.Height)
             {
-                if (link.TargetPage.HasValue)
-                    Page = link.TargetPage.Value;
+                var linkClickEventArgs = new LinkClickEventArgs(link);
+                HandleLinkClick(linkClickEventArgs);
+            }
+        }
 
-                if (link.Uri != null)
+        private void HandleLinkClick(LinkClickEventArgs e)
+        {
+            OnLinkClick(e);
+
+            if (e.Handled)
+                return;
+
+            if (e.Link.TargetPage.HasValue)
+                Page = e.Link.TargetPage.Value;
+
+            if (e.Link.Uri != null)
+            {
+                try
                 {
-                    try
-                    {
-                        Process.Start(link.Uri);
-                    }
-                    catch
-                    {
-                        // Some browsers (Firefox) will cause an exception to
-                        // be thrown (when it auto-updates).
-                    }
+                    Process.Start(e.Link.Uri);
+                }
+                catch
+                {
+                    // Some browsers (Firefox) will cause an exception to
+                    // be thrown (when it auto-updates).
                 }
             }
+        }
+
+        /// <summary>
+        /// Occurs when a link in the pdf document is clicked.
+        /// </summary>
+        [Category("Action")]
+        [Description("Occurs when a link in the pdf document is clicked.")]
+        public event LinkClickEventHandler LinkClick;
+
+        protected virtual void OnLinkClick(LinkClickEventArgs e)
+        {
+            var handler = LinkClick;
+            if (handler != null)
+                handler(this, e);
         }
 
         /// <summary>

--- a/PdfiumViewer/PdfViewer.Designer.cs
+++ b/PdfiumViewer/PdfViewer.Designer.cs
@@ -128,6 +128,7 @@ namespace PdfiumViewer
             this._renderer.Page = 0;
             this._renderer.Rotation = PdfiumViewer.PdfRotation.Rotate0;
             this._renderer.ZoomMode = PdfiumViewer.PdfViewerZoomMode.FitHeight;
+            this._renderer.LinkClick += new PdfiumViewer.LinkClickEventHandler(this._renderer_LinkClick);
             // 
             // PdfViewer
             // 

--- a/PdfiumViewer/PdfViewer.cs
+++ b/PdfiumViewer/PdfViewer.cs
@@ -86,6 +86,20 @@ namespace PdfiumViewer
             }
         }
 
+        /// <summary>
+        /// Occurs when a link in the pdf document is clicked.
+        /// </summary>
+        [Category("Action")]
+        [Description("Occurs when a link in the pdf document is clicked.")]
+        public event LinkClickEventHandler LinkClick;
+
+        protected virtual void OnLinkClick(LinkClickEventArgs e)
+        {
+            var handler = LinkClick;
+            if (handler != null)
+                handler(this, e);
+        }
+
         private void UpdateBookmarks()
         {
             bool visible = _showBookmarks && _document != null && _document.Bookmarks.Count > 0;
@@ -203,6 +217,11 @@ namespace PdfiumViewer
         private void _bookmarks_AfterSelect(object sender, TreeViewEventArgs e)
         {
             _renderer.Page = ((PdfBookmark)e.Node.Tag).PageIndex;
+        }
+
+        private void _renderer_LinkClick(object sender, LinkClickEventArgs e)
+        {
+            OnLinkClick(e);
         }
     }
 }

--- a/PdfiumViewer/PdfiumViewer.csproj
+++ b/PdfiumViewer/PdfiumViewer.csproj
@@ -50,6 +50,7 @@
       <SubType>Component</SubType>
     </Compile>
     <Compile Include="HitTest.cs" />
+    <Compile Include="LinkClickEventHandler.cs" />
     <Compile Include="MouseWheelMode.cs" />
     <Compile Include="NativeMethods.cs" />
     <Compile Include="NativeMethods.Pdfium.cs" />


### PR DESCRIPTION
Thanks for a nice library! This patch adds an event to PdfRenderer and PdfViewer to enable users of the control to customize how links are handled. E.g.:

``` csharp
private void InitializeComponent()
{
    this.pdfViewer = new PdfViewer();
    this.pdfViewer.LinkClick += pdfViewer_LinkClick;
}

private void pdfViewer_LinkClick(object sender, LinkClickEventArgs e)
{
    if (e.Link.Uri != null)
    {
        OpenNewTab(e.Link.Uri);
        e.Handled = true;
    }
}
```
