### PR TITLE
Reference native dlls from Nuget

### DIFF
--- a/PdfiumViewer/PdfiumViewer.csproj
+++ b/PdfiumViewer/PdfiumViewer.csproj
@@ -150,16 +150,6 @@
   <ItemGroup>
     <EmbeddedResource Include="pan.cur" />
   </ItemGroup>
-  <ItemGroup>
-    <Content Include="..\Libraries\Pdfium\x64\pdfium.dll">
-      <Link>x64\pdfium.dll</Link>
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\Libraries\Pdfium\x86\pdfium.dll">
-      <Link>x86\pdfium.dll</Link>
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/PdfiumViewer/PdfiumViewer.nuspec
+++ b/PdfiumViewer/PdfiumViewer.nuspec
@@ -14,8 +14,9 @@
     <tags>pdf viewer pdfium</tags>
   </metadata>
   <files>
-    <file src="..\Libraries\Pdfium\x86\pdfium.dll" target="content\x86" />
-    <file src="..\Libraries\Pdfium\x64\pdfium.dll" target="content\x64" />
+    <file src="..\Libraries\Pdfium\x86\pdfium.dll" target="build\x86" />
+    <file src="..\Libraries\Pdfium\x64\pdfium.dll" target="build\x64" />
+    <file src="PdfiumViewer.props" target="build" />
     <file src="bin\Release\nl\*.dll" target="lib\net20\nl" />
   </files>
 </package>

--- a/PdfiumViewer/PdfiumViewer.props
+++ b/PdfiumViewer/PdfiumViewer.props
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Content Include="$(MSBuildThisFileDirectory)x86\pdfium.dll">
+      <Link>x86\pdfium.dll</Link>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="$(MSBuildThisFileDirectory)x64\pdfium.dll">
+      <Link>x64\pdfium.dll</Link>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
added MSBuild props to PdfiumViewer nuget package in order to include native pdfium.dlls into project at consumer side, which fixes #111