### PR TITLE
fix handling of PDFs that are smaller than 72 in either width or height

### DIFF
--- a/PdfiumViewer/PdfDocument.cs
+++ b/PdfiumViewer/PdfDocument.cs
@@ -294,8 +294,8 @@ namespace PdfiumViewer
 
             if ((flags & PdfRenderFlags.CorrectFromDpi) != 0)
             {
-                width = width / 72 * (int)dpiX;
-                height = height / 72 * (int)dpiY;
+                width = width * (int)dpiX / 72;
+                height = height * (int)dpiY / 72;
             }
 
             var bitmap = new Bitmap(width, height, PixelFormat.Format32bppArgb);


### PR DESCRIPTION
right now since the division is done prior to multiplication, any PDF who's width or height is smaller than 72 will have that dimension set to 0 and thus the conversion will throw an exception.  This change fixes this issue.