### PR TITLE
Adds default printer property;

### DIFF
--- a/PdfiumViewer/PdfViewer.cs
+++ b/PdfiumViewer/PdfViewer.cs
@@ -93,6 +93,13 @@ namespace PdfiumViewer
         }
 
         /// <summary>
+        /// Gets or sets the pre-selected printer to be used when the print
+        /// dialog shows up.
+        /// </summary>
+        [DefaultValue("")]
+        public string DefaultPrinter { get; set; }
+
+        /// <summary>
         /// Occurs when a link in the pdf document is clicked.
         /// </summary>
         [Category("Action")]
@@ -196,6 +203,7 @@ namespace PdfiumViewer
                 form.UseEXDialog = true;
                 form.Document.PrinterSettings.FromPage = 1;
                 form.Document.PrinterSettings.ToPage = _document.PageCount;
+                form.Document.PrinterSettings.PrinterName = DefaultPrinter;
 
                 if (form.ShowDialog(FindForm()) == DialogResult.OK)
                 {


### PR DESCRIPTION
I loved your component but it was missing a small setting that would allow me to fulfill my requirements.

So what I did was basically externalize a property where a printer can be pre-selected when clicking the _print_ button. If used the default _empty_, the default printer will be selected automatically by the print dialog.

By setting this property, when clicking the _print_ button, the printer with that name will be the one selected for printing, instead of the default printer.

Thank you for the component!