### PR TITLE
Try load native dlls from Assembly.CodeBase if other attempts failed

### DIFF
--- a/PdfiumViewer/NativeMethods.cs
+++ b/PdfiumViewer/NativeMethods.cs
@@ -17,8 +17,15 @@ namespace PdfiumViewer
         {
             // Load the platform dependent Pdfium.dll if it exists.
 
-            if (!TryLoadNativeLibrary(AppDomain.CurrentDomain.RelativeSearchPath))
-                TryLoadNativeLibrary(Path.GetDirectoryName(typeof (NativeMethods).Assembly.Location));
+            bool loaded = TryLoadNativeLibrary(AppDomain.CurrentDomain.RelativeSearchPath) ||
+                          TryLoadNativeLibrary(Path.GetDirectoryName(typeof(NativeMethods).Assembly.Location));
+            if (!loaded) {
+                // Convert URI to file system path
+                Uri dllBaseUri = new Uri(typeof(NativeMethods).Assembly.CodeBase);
+                if (dllBaseUri.IsFile) {
+                    TryLoadNativeLibrary(Path.GetDirectoryName(dllBaseUri.AbsolutePath));
+                }
+            }
         }
 
         private static bool TryLoadNativeLibrary(string path)


### PR DESCRIPTION
.NET uses shadow copying of assemblies in many cases, which prevents
the library from finding the native dlls when only considering
Assembly.Location property. Assembly.CodeBase refers to the original
location of the assembly and reflects actual information on where the
native binaries should be located. This fix should fix problem with
using library in environments using shadow copying such as ASP.NET and
NUnit tests.

Related to Bug #109