### PR TITLE
Get detailed character information for a pdf page

### DIFF
--- a/PdfiumViewer.Demo/PdfRangeDocument.cs
+++ b/PdfiumViewer.Demo/PdfRangeDocument.cs
@@ -288,6 +288,11 @@ namespace PdfiumViewer.Demo
             return _document.RectangleFromPdf(TranslatePage(page), rect);
         }
 
+        public IList<PdfCharacterInformation> GetCharacterInformation(int page)
+        {
+            return _document.GetCharacterInformation(page);
+        }
+
         private int TranslatePage(int page)
         {
             if (page < 0 || page >= PageCount)

--- a/PdfiumViewer/IPdfDocument.cs
+++ b/PdfiumViewer/IPdfDocument.cs
@@ -252,5 +252,12 @@ namespace PdfiumViewer
         /// <param name="rect">The rectangle to convert.</param>
         /// <returns>The converted rectangle.</returns>
         Rectangle RectangleFromPdf(int page, RectangleF rect);
+
+        /// <summary>
+        /// Get detailed information for all characters on the page.
+        /// </summary>
+        /// <param name="page">The page to get the information for.</param>
+        /// <returns>The character information.</returns>
+        IList<PdfCharacterInformation> GetCharacterInformation(int page);
     }
 }

--- a/PdfiumViewer/NativeMethods.Pdfium.cs
+++ b/PdfiumViewer/NativeMethods.Pdfium.cs
@@ -258,6 +258,14 @@ namespace PdfiumViewer
             }
         }
 
+        public static double FPDFText_GetFontSize(IntPtr page, int index)
+        {
+            lock (LockString)
+            {
+                return Imports.FPDFText_GetFontSize(page, index);
+            }
+        }
+
         public static int FPDFText_GetSchResultIndex(IntPtr handle)
         {
             lock (LockString)
@@ -683,6 +691,9 @@ namespace PdfiumViewer
 
             [DllImport("pdfium.dll")]
             public static extern IntPtr FPDFText_FindStart(IntPtr page, byte[] findWhat, FPDF_SEARCH_FLAGS flags, int start_index);
+
+            [DllImport("pdfium.dll")]
+            public static extern double FPDFText_GetFontSize(IntPtr page, int index);
 
             [DllImport("pdfium.dll")]
             public static extern int FPDFText_GetSchResultIndex(IntPtr handle);

--- a/PdfiumViewer/PdfCharacterInformation.cs
+++ b/PdfiumViewer/PdfCharacterInformation.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Text;
+
+namespace PdfiumViewer
+{
+    public struct PdfCharacterInformation
+    {
+        public int Page { get; }
+        public int Offset { get; }
+        public double FontSize { get; }
+        public char Character { get; }
+        public RectangleF Bounds { get; }
+
+        public PdfCharacterInformation(int page, int offset, char character, double fontSize, RectangleF bounds)
+        {
+            Page = page;
+            Offset = offset;
+            FontSize = fontSize;
+            Bounds = bounds;
+            Character = character;
+        }
+
+    }
+}

--- a/PdfiumViewer/PdfDocument.cs
+++ b/PdfiumViewer/PdfDocument.cs
@@ -598,5 +598,15 @@ namespace PdfiumViewer
                 _disposed = true;
             }
         }
+
+        /// <summary>
+        /// Get detailed information all characters on the page.
+        /// </summary>
+        /// <param name="page">The page to get the information for.</param>
+        /// <returns>The character information.</returns>
+        public IList<PdfCharacterInformation> GetCharacterInformation(int page)
+        {
+            return _file.GetCharacterInformation(page);
+        }
     }
 }

--- a/PdfiumViewer/PdfFile.cs
+++ b/PdfiumViewer/PdfFile.cs
@@ -497,6 +497,24 @@ namespace PdfiumViewer
             return FPDFEncoding.GetString(result, 0, textSpan.Length * 2);
         }
 
+        public IList<PdfCharacterInformation> GetCharacterInformation(int page)
+        {
+            using (var pageData = new PageData(_document, _form, page))
+            {
+                var result = new List<PdfCharacterInformation>();
+                int charCount = NativeMethods.FPDFText_CountChars(pageData.TextPage);
+                var allChars = GetPdfText(pageData, new PdfTextSpan(page, 0, charCount)).ToCharArray();
+
+                for (int i = 0; i < charCount; i++)
+                {
+                    var bounds = GetBounds(pageData.TextPage, i);
+                    double fontSize = NativeMethods.FPDFText_GetFontSize(pageData.TextPage, i);
+                    result.Add(new PdfCharacterInformation(page, i, allChars[i], fontSize, bounds));
+                }
+
+                return result;
+            }
+        }
         public void DeletePage (int pageNumber)
         {
             NativeMethods.FPDFPage_Delete(_document, pageNumber);

--- a/PdfiumViewer/PdfiumViewer.csproj
+++ b/PdfiumViewer/PdfiumViewer.csproj
@@ -71,6 +71,7 @@
     <Compile Include="PdfBookmarkCollection.cs" />
     <Compile Include="PdfiumResolveEventHandler.cs" />
     <Compile Include="PdfiumResolver.cs" />
+    <Compile Include="PdfCharacterInformation.cs" />
     <Compile Include="PdfPrintMultiplePages.cs" />
     <Compile Include="PdfPrintSettings.cs" />
     <Compile Include="PdfRectangle.cs" />


### PR DESCRIPTION
Adds GetCharacterInformation function to PdfDocument which will retrieve detailed info about every character on a page, including:
- Character: the actual char
- FontSize
- Bounds

This info can be used for a variety of applications, including rendering visual boundaries on text, identifying text within certain regions, parsing page content into logical units based on position, such as words, tables, etc.