### PR TITLE
Use PdfRenderFlags.CorrectFromDpi so that the DPI settings in 'Export bitmaps' have an effect.

### DIFF
--- a/PdfiumViewer.Demo/MainForm.cs
+++ b/PdfiumViewer.Demo/MainForm.cs
@@ -157,7 +157,7 @@ namespace PdfiumViewer.Demo
 
             for (int i = 0; i < document.PageCount; i++)
             {
-                using (var image = document.Render(i, (int)document.PageSizes[i].Width, (int)document.PageSizes[i].Height, dpiX, dpiY, false))
+                using (var image = document.Render(i, (int)document.PageSizes[i].Width, (int)document.PageSizes[i].Height, dpiX, dpiY, PdfRenderFlags.CorrectFromDpi))
                 {
                     image.Save(Path.Combine(path, "Page " + i + ".png"));
                 }


### PR DESCRIPTION
When testing out the PdfiumViewer library, I found that changing the DPI settings in the Tools - Render to Bitmaps (Export bitmaps) had no obvious effect.

Passing in PdfRenderFlags.CorrectFromDpi rather than (boolean) false appears to correct the issue.