### PR TITLE
Check division by zero in scale calculation in SetDisplayRectangleSize

### DIFF
--- a/PdfiumViewer/CustomScrollControl.cs
+++ b/PdfiumViewer/CustomScrollControl.cs
@@ -348,8 +348,8 @@ namespace PdfiumViewer
         {
             bool needLayout = false;
 
-            double hScale = (double)width / _displayRect.Height;
-            double vScale = (double)height / _displayRect.Height;
+            double hScale = _displayRect.Height==0 ? 1 :(double)width / _displayRect.Width;
+            double vScale = _displayRect.Height==0? 1 : (double)height / _displayRect.Height;
 
             if (_displayRect.Width != width || _displayRect.Height != height)
             {


### PR DESCRIPTION
It happens that when the application starts SetDisplayRectangleSize arrives with _displayRect zero and it gives a division by zero exception. 
Also there was a bug in calculation of hScale referring Height instead of Width