### PR TITLE
Support text selection

### DIFF
--- a/PdfiumViewer.Demo/MainForm.Designer.cs
+++ b/PdfiumViewer.Demo/MainForm.Designer.cs
@@ -32,12 +32,14 @@ namespace PdfiumViewer.Demo
         /// </summary>
         private void InitializeComponent()
         {
+            this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(MainForm));
             this.menuStrip1 = new System.Windows.Forms.MenuStrip();
             this.fileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.openToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripMenuItem1 = new System.Windows.Forms.ToolStripSeparator();
             this.printPreviewToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.printMultiplePagesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripMenuItem3 = new System.Windows.Forms.ToolStripSeparator();
             this.exitToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -86,11 +88,14 @@ namespace PdfiumViewer.Demo
             this._pageToolStripLabel = new System.Windows.Forms.ToolStripStatusLabel();
             this.toolStripStatusLabel2 = new System.Windows.Forms.ToolStripStatusLabel();
             this._coordinatesToolStripLabel = new System.Windows.Forms.ToolStripStatusLabel();
+            this.pdfViewerContextMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.copyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.selectAllToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.pdfViewer1 = new PdfiumViewer.PdfViewer();
-            this.printMultiplePagesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.menuStrip1.SuspendLayout();
             this.toolStrip1.SuspendLayout();
             this.statusStrip1.SuspendLayout();
+            this.pdfViewerContextMenu.SuspendLayout();
             this.SuspendLayout();
             // 
             // menuStrip1
@@ -136,6 +141,13 @@ namespace PdfiumViewer.Demo
             this.printPreviewToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
             this.printPreviewToolStripMenuItem.Text = "Print Preview";
             this.printPreviewToolStripMenuItem.Click += new System.EventHandler(this.printPreviewToolStripMenuItem_Click);
+            // 
+            // printMultiplePagesToolStripMenuItem
+            // 
+            this.printMultiplePagesToolStripMenuItem.Name = "printMultiplePagesToolStripMenuItem";
+            this.printMultiplePagesToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.printMultiplePagesToolStripMenuItem.Text = "Print Multiple Pages";
+            this.printMultiplePagesToolStripMenuItem.Click += new System.EventHandler(this.printMultiplePagesToolStripMenuItem_Click);
             // 
             // toolStripMenuItem3
             // 
@@ -529,6 +541,29 @@ namespace PdfiumViewer.Demo
             this._coordinatesToolStripLabel.Size = new System.Drawing.Size(77, 17);
             this._coordinatesToolStripLabel.Text = "(coordinates)";
             // 
+            // pdfViewerContextMenu
+            // 
+            this.pdfViewerContextMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.copyToolStripMenuItem,
+            this.selectAllToolStripMenuItem});
+            this.pdfViewerContextMenu.Name = "pdfViewerContextMenu";
+            this.pdfViewerContextMenu.Size = new System.Drawing.Size(123, 48);
+            this.pdfViewerContextMenu.Opening += new System.ComponentModel.CancelEventHandler(this.pdfViewerContextMenu_Opening);
+            // 
+            // copyToolStripMenuItem
+            // 
+            this.copyToolStripMenuItem.Name = "copyToolStripMenuItem";
+            this.copyToolStripMenuItem.Size = new System.Drawing.Size(122, 22);
+            this.copyToolStripMenuItem.Text = "&Copy";
+            this.copyToolStripMenuItem.Click += new System.EventHandler(this.copyToolStripMenuItem_Click);
+            // 
+            // selectAllToolStripMenuItem
+            // 
+            this.selectAllToolStripMenuItem.Name = "selectAllToolStripMenuItem";
+            this.selectAllToolStripMenuItem.Size = new System.Drawing.Size(122, 22);
+            this.selectAllToolStripMenuItem.Text = "Select &All";
+            this.selectAllToolStripMenuItem.Click += new System.EventHandler(this.selectAllToolStripMenuItem_Click);
+            // 
             // pdfViewer1
             // 
             this.pdfViewer1.Dock = System.Windows.Forms.DockStyle.Fill;
@@ -536,13 +571,6 @@ namespace PdfiumViewer.Demo
             this.pdfViewer1.Name = "pdfViewer1";
             this.pdfViewer1.Size = new System.Drawing.Size(1128, 524);
             this.pdfViewer1.TabIndex = 0;
-            // 
-            // printMultiplePagesToolStripMenuItem
-            // 
-            this.printMultiplePagesToolStripMenuItem.Name = "printMultiplePagesToolStripMenuItem";
-            this.printMultiplePagesToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
-            this.printMultiplePagesToolStripMenuItem.Text = "Print Multiple Pages";
-            this.printMultiplePagesToolStripMenuItem.Click += new System.EventHandler(this.printMultiplePagesToolStripMenuItem_Click);
             // 
             // MainForm
             // 
@@ -563,6 +591,7 @@ namespace PdfiumViewer.Demo
             this.toolStrip1.PerformLayout();
             this.statusStrip1.ResumeLayout(false);
             this.statusStrip1.PerformLayout();
+            this.pdfViewerContextMenu.ResumeLayout(false);
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -625,6 +654,9 @@ namespace PdfiumViewer.Demo
         private System.Windows.Forms.ToolStripMenuItem findToolStripMenuItem;
         private System.Windows.Forms.ToolStripSeparator toolStripMenuItem7;
         private System.Windows.Forms.ToolStripMenuItem printMultiplePagesToolStripMenuItem;
+        private System.Windows.Forms.ContextMenuStrip pdfViewerContextMenu;
+        private System.Windows.Forms.ToolStripMenuItem copyToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem selectAllToolStripMenuItem;
     }
 }
 

--- a/PdfiumViewer.Demo/MainForm.cs
+++ b/PdfiumViewer.Demo/MainForm.cs
@@ -19,6 +19,8 @@ namespace PdfiumViewer.Demo
 
             renderToBitmapsToolStripMenuItem.Enabled = false;
 
+            pdfViewer1.Renderer.ContextMenuStrip = pdfViewerContextMenu;
+
             pdfViewer1.Renderer.DisplayRectangleChanged += Renderer_DisplayRectangleChanged;
             pdfViewer1.Renderer.ZoomChanged += Renderer_ZoomChanged;
 
@@ -377,6 +379,21 @@ namespace PdfiumViewer.Demo
             {
                 form.ShowDialog(this);
             }
+        }
+
+        private void copyToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            pdfViewer1.Renderer.CopySelection();
+        }
+
+        private void selectAllToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            pdfViewer1.Renderer.SelectAll();
+        }
+
+        private void pdfViewerContextMenu_Opening(object sender, CancelEventArgs e)
+        {
+            copyToolStripMenuItem.Enabled = pdfViewer1.Renderer.IsTextSelected;
         }
     }
 }

--- a/PdfiumViewer.Demo/MainForm.resx
+++ b/PdfiumViewer.Demo/MainForm.resx
@@ -307,4 +307,7 @@
   <metadata name="statusStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>237, 17</value>
   </metadata>
+  <metadata name="pdfViewerContextMenu.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>353, 17</value>
+  </metadata>
 </root>

--- a/PdfiumViewer.Demo/PdfRangeDocument.cs
+++ b/PdfiumViewer.Demo/PdfRangeDocument.cs
@@ -288,6 +288,26 @@ namespace PdfiumViewer.Demo
             return _document.RectangleFromPdf(TranslatePage(page), rect);
         }
 
+        public int GetCharacterIndexAtPosition(PdfPoint location, double xTolerance, double yTolerance)
+        {
+            return _document.GetCharacterIndexAtPosition(location, xTolerance, yTolerance);
+        }
+
+        public bool GetWordAtPosition(PdfPoint location, double xTolerance, double yTolerance, out PdfTextSpan span)
+        {
+            return _document.GetWordAtPosition(location, xTolerance, yTolerance, out span);
+        }
+
+        public int CountCharacters(int page)
+        {
+            return _document.CountCharacters(page);
+        }
+
+        public List<PdfRectangle> GetTextRectangles(int page, int startIndex, int count)
+        {
+            return _document.GetTextRectangles(page, startIndex, count);
+        }
+
         private int TranslatePage(int page)
         {
             if (page < 0 || page >= PageCount)

--- a/PdfiumViewer/IPdfDocument.cs
+++ b/PdfiumViewer/IPdfDocument.cs
@@ -252,5 +252,38 @@ namespace PdfiumViewer
         /// <param name="rect">The rectangle to convert.</param>
         /// <returns>The converted rectangle.</returns>
         Rectangle RectangleFromPdf(int page, RectangleF rect);
+
+        /// <summary>
+        /// Get the character index at or nearby a specific position. 
+        /// </summary>
+        /// <param name="location">The location to inspect</param>
+        /// <param name="xTolerance">An x-axis tolerance value for character hit detection, in point unit.</param>
+        /// <param name="yTolerance">A y-axis tolerance value for character hit detection, in point unit.</param>
+        /// <returns>The zero-based index of the character at, or nearby the point specified by parameter x and y. If there is no character at or nearby the point, it will return -1.</returns>
+        int GetCharacterIndexAtPosition(PdfPoint location, double xTolerance, double yTolerance);
+
+        /// <summary>
+        /// Get the full word at or nearby a specific position
+        /// </summary>
+        /// <param name="location">The location to inspect</param>
+        /// <param name="xTolerance">An x-axis tolerance value for character hit detection, in point unit.</param>
+        /// <param name="yTolerance">A y-axis tolerance value for character hit detection, in point unit.</param>
+        /// <param name="span">The location of the found word, if any</param>
+        /// <returns>A value indicating whether a word was found at the specified location</returns>
+        bool GetWordAtPosition(PdfPoint location, double xTolerance, double yTolerance, out PdfTextSpan span);
+
+        /// <summary>
+        /// Get number of characters in a page.
+        /// </summary>
+        /// <param name="page">The page to get the character count from</param>
+        /// <returns>Number of characters in the page. Generated characters, like additional space characters, new line characters, are also counted.</returns>
+        int CountCharacters(int page);
+
+        /// <summary>
+        /// Gets the rectangular areas occupied by a segment of text
+        /// </summary>
+        /// <param name="page">The page to get the rectangles from</param>
+        /// <returns>The rectangular areas occupied by a segment of text</returns>
+        List<PdfRectangle> GetTextRectangles(int page, int startIndex, int count);
     }
 }

--- a/PdfiumViewer/PanningZoomingScrollControl.cs
+++ b/PdfiumViewer/PanningZoomingScrollControl.cs
@@ -120,6 +120,8 @@ namespace PdfiumViewer
         [DefaultValue(MouseWheelMode.PanAndZoom)]
         public MouseWheelMode MouseWheelMode { get; set; }
 
+        protected bool MousePanningEnabled { get; set; } = true;
+
         /// <summary>
         /// Raises the <see cref="E:System.Windows.Forms.Control.MouseWheel"/> event.
         /// </summary>
@@ -226,7 +228,7 @@ namespace PdfiumViewer
 
         protected override void OnSetCursor(SetCursorEventArgs e)
         {
-            if (_canPan && e.HitTest == HitTest.Client)
+            if (MousePanningEnabled && _canPan && e.HitTest == HitTest.Client)
                 e.Cursor = PanCursor;
 
             base.OnSetCursor(e);
@@ -243,7 +245,7 @@ namespace PdfiumViewer
         {
             base.OnMouseDown(e);
 
-            if (e.Button != MouseButtons.Left || !_canPan)
+            if (!MousePanningEnabled || e.Button != MouseButtons.Left || !_canPan)
                 return;
 
             Capture = true;
@@ -255,7 +257,7 @@ namespace PdfiumViewer
         {
             base.OnMouseMove(e);
 
-            if (!Capture)
+            if (!MousePanningEnabled || !Capture)
                 return;
 
             var offset = new Point(e.Location.X - _dragStart.X, e.Location.Y - _dragStart.Y);
@@ -267,7 +269,8 @@ namespace PdfiumViewer
         {
             base.OnMouseUp(e);
 
-            Capture = false;
+            if (MousePanningEnabled)
+                Capture = false;
         }
 
         private class WheelFilter : IMessageFilter

--- a/PdfiumViewer/PdfDocument.cs
+++ b/PdfiumViewer/PdfDocument.cs
@@ -505,6 +505,53 @@ namespace PdfiumViewer
         }
 
         /// <summary>
+        /// Get the character index at or nearby a specific position. 
+        /// </summary>
+        /// <param name="page">The page to get the character index from</param>
+        /// <param name="x">X position</param>
+        /// <param name="y">Y position</param>
+        /// <param name="xTolerance">An x-axis tolerance value for character hit detection, in point unit.</param>
+        /// <param name="yTolerance">A y-axis tolerance value for character hit detection, in point unit.</param>
+        /// <returns>The zero-based index of the character at, or nearby the point specified by parameter x and y. If there is no character at or nearby the point, it will return -1.</returns>
+        public int GetCharacterIndexAtPosition(PdfPoint location, double xTolerance, double yTolerance)
+        {
+            return _file.GetCharIndexAtPos(location, xTolerance, yTolerance);
+        }
+
+        /// <summary>
+        /// Get the full word at or nearby a specific position
+        /// </summary>
+        /// <param name="location">The location to inspect</param>
+        /// <param name="xTolerance">An x-axis tolerance value for character hit detection, in point unit.</param>
+        /// <param name="yTolerance">A y-axis tolerance value for character hit detection, in point unit.</param>
+        /// <param name="span">The location of the found word, if any</param>
+        /// <returns>A value indicating whether a word was found at the specified location</returns>
+        public bool GetWordAtPosition(PdfPoint location, double xTolerance, double yTolerance, out PdfTextSpan span)
+        {
+            return _file.GetWordAtPosition(location, xTolerance, yTolerance, out span);
+        }
+
+        /// <summary>
+        /// Get number of characters in a page.
+        /// </summary>
+        /// <param name="page">The page to get the character count from</param>
+        /// <returns>Number of characters in the page. Generated characters, like additional space characters, new line characters, are also counted.</returns>
+        public int CountCharacters(int page)
+        {
+            return _file.CountChars(page);
+        }
+
+        /// <summary>
+        /// Gets the rectangular areas occupied by a segment of text
+        /// </summary>
+        /// <param name="page">The page to get the rectangles from</param>
+        /// <returns>The rectangular areas occupied by a segment of text</returns>
+        public List<PdfRectangle> GetTextRectangles(int page, int startIndex, int count)
+        {
+            return _file.GetTextRectangles(page, startIndex, count);
+        }
+
+        /// <summary>
         /// Creates a <see cref="PrintDocument"/> for the PDF document.
         /// </summary>
         /// <returns></returns>

--- a/PdfiumViewer/PdfRenderer.cs
+++ b/PdfiumViewer/PdfRenderer.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing;
+using System.Text;
 using System.Windows.Forms;
 
 namespace PdfiumViewer
@@ -13,6 +14,7 @@ namespace PdfiumViewer
     public class PdfRenderer : PanningZoomingScrollControl
     {
         private static readonly Padding PageMargin = new Padding(4);
+        private static readonly SolidBrush _textSelectionBrush = new SolidBrush(Color.FromArgb(90, Color.DodgerBlue));
 
         private int _height;
         private int _maxWidth;
@@ -32,6 +34,10 @@ namespace PdfiumViewer
         private DragState _dragState;
         private PdfRotation _rotation;
         private List<IPdfMarker>[] _markers;
+        private PdfViewerCursorMode _cursorMode = PdfViewerCursorMode.Pan;
+        private bool _isSelectingText = false;
+        private MouseState _cachedMouseState = null;
+        private TextSelectionState _textSelectionState = null;
 
         /// <summary>
         /// The associated PDF document.
@@ -126,6 +132,20 @@ namespace PdfiumViewer
         }
 
         /// <summary>
+        /// Gets or sets the way the viewer should respond to cursor input
+        /// </summary>
+        [DefaultValue(PdfViewerCursorMode.Pan)]
+        public PdfViewerCursorMode CursorMode
+        {
+            get { return _cursorMode; }
+            set
+            {
+                _cursorMode = value;
+                MousePanningEnabled = _cursorMode == PdfViewerCursorMode.Pan;
+            }
+        }
+
+        /// <summary>
         /// Gets or sets the current rotation of the PDF document.
         /// </summary>
         public PdfRotation Rotation
@@ -138,6 +158,52 @@ namespace PdfiumViewer
                     _rotation = value;
                     ResetFromRotation();
                 }
+            }
+        }
+
+        public bool IsTextSelected
+        {
+            get
+            {
+                var state = _textSelectionState?.GetNormalized();
+                if (state == null)
+                    return false;
+
+                if (state.EndPage < 0 || state.EndIndex < 0)
+                    return false;
+
+                return true;
+            }
+        }
+
+        public string SelectedText
+        {
+            get
+            {
+                var state = _textSelectionState?.GetNormalized();
+                if (state == null)
+                    return null;
+
+                var sb = new StringBuilder();
+                for (int page = state.StartPage; page <= state.EndPage; page++)
+                {
+                    int start = 0, end = 0;
+
+                    if (page == state.StartPage)
+                        start = state.StartIndex;
+
+                    if (page == state.EndPage)
+                        end = (state.EndIndex + 1);
+                    else
+                        end = Document.CountCharacters(page);
+
+                    if (page != state.StartPage)
+                        sb.AppendLine();
+
+                    sb.Append(Document.GetPdfText(new PdfTextSpan(page, start, end - start)));
+                }
+
+                return sb.ToString();
             }
         }
 
@@ -283,7 +349,7 @@ namespace PdfiumViewer
         {
             return BoundsFromPdf(bounds, true);
         }
-            
+
         private Rectangle BoundsFromPdf(PdfRectangle bounds, bool translateOffset)
         {
             var offset = translateOffset ? GetScrollOffset() : Size.Empty;
@@ -382,6 +448,52 @@ namespace PdfiumViewer
             base.OnZoomChanged(e);
 
             UpdateScrollbars();
+        }
+
+        /// <summary>
+        /// Determines whether the specified key is a regular input key or a special key that requires preprocessing.
+        /// </summary>
+        /// <returns>
+        /// true if the specified key is a regular input key; otherwise, false.
+        /// </returns>
+        /// <param name="keyData">One of the <see cref="T:System.Windows.Forms.Keys"/> values. </param>
+        protected override bool IsInputKey(Keys keyData)
+        {
+            switch ((keyData) & Keys.KeyCode)
+            {
+                case Keys.A:
+                    if ((keyData & Keys.Modifiers) == Keys.Control)
+                        SelectAll();
+                    return true;
+
+                case Keys.C:
+                    if ((keyData & Keys.Modifiers) == Keys.Control)
+                        CopySelection();
+                    return true;
+
+                default:
+                    return base.IsInputKey(keyData);
+            }
+        }
+
+        public void SelectAll()
+        {
+            _textSelectionState = new TextSelectionState()
+            {
+                StartPage = 0,
+                StartIndex = 0,
+                EndPage = Document.PageCount - 1,
+                EndIndex = Document.CountCharacters(Document.PageCount - 1) - 1
+            };
+
+            Invalidate();
+        }
+
+        public void CopySelection()
+        {
+            var text = SelectedText;
+            if (text.Length > 0)
+                Clipboard.SetText(text);
         }
 
         /// <summary>
@@ -653,6 +765,10 @@ namespace PdfiumViewer
                     _shadeBorder.Draw(e.Graphics, pageBounds);
 
                     DrawMarkers(e.Graphics, page);
+
+                    var selectionInfo = _textSelectionState;
+                    if (selectionInfo != null)
+                        DrawTextSelection(e.Graphics, page, selectionInfo.GetNormalized());
                 }
             }
 
@@ -660,6 +776,37 @@ namespace PdfiumViewer
                 _visiblePageStart = 0;
             if (_visiblePageEnd == -1)
                 _visiblePageEnd = Document.PageCount - 1;
+        }
+
+        private void DrawTextSelection(Graphics graphics, int page, TextSelectionState state)
+        {
+            if (state.EndPage < 0 || state.EndIndex < 0)
+                return;
+
+            if (page >= state.StartPage && page <= state.EndPage)
+            {
+                int start = 0, end = 0;
+
+                if (page == state.StartPage)
+                    start = state.StartIndex;
+
+                if (page == state.EndPage)
+                    end = (state.EndIndex + 1);
+                else
+                    end = Document.CountCharacters(page);
+
+                Region region = null;
+                foreach (var rectangle in Document.GetTextRectangles(page, start, end - start))
+                {
+                    if (region == null)
+                        region = new Region(BoundsFromPdf(rectangle));
+                    else
+                        region.Union(BoundsFromPdf(rectangle));
+                }
+
+                if (region != null)
+                    graphics.FillRegion(_textSelectionBrush, region);
+            }
         }
 
         private void DrawPageImage(Graphics graphics, int page, Rectangle pageBounds)
@@ -731,6 +878,16 @@ namespace PdfiumViewer
                         }
                     }
                 }
+
+                if (_cursorMode == PdfViewerCursorMode.TextSelection)
+                {
+                    var state = GetMouseState(e.Location);
+                    if (state.CharacterIndex >= 0)
+                    {
+                        e.Cursor = Cursors.IBeam;
+                        return;
+                    }
+                }
             }
 
             base.OnSetCursor(e);
@@ -742,6 +899,50 @@ namespace PdfiumViewer
         {
             base.OnMouseDown(e);
 
+            HandleMouseDownForLinks(e);
+
+            if (_cursorMode == PdfViewerCursorMode.TextSelection)
+            {
+                HandleMouseDownForTextSelection(e);
+            }
+        }
+
+        /// <summary>Raises the <see cref="E:System.Windows.Forms.Control.MouseUp" /> event.</summary>
+        /// <param name="e">A <see cref="T:System.Windows.Forms.MouseEventArgs" /> that contains the event data. </param>
+        protected override void OnMouseUp(MouseEventArgs e)
+        {
+            base.OnMouseUp(e);
+
+            HandleMouseUpForLinks(e);
+
+            if (_cursorMode == PdfViewerCursorMode.TextSelection)
+            {
+                HandleMouseUpForTextSelection(e);
+            }
+        }
+
+        protected override void OnMouseMove(MouseEventArgs e)
+        {
+            base.OnMouseMove(e);
+
+            if (_cursorMode == PdfViewerCursorMode.TextSelection)
+            {
+                HandleMouseMoveForTextSelection(e);
+            }
+        }
+
+        protected override void OnMouseDoubleClick(MouseEventArgs e)
+        {
+            base.OnMouseDoubleClick(e);
+
+            if (_cursorMode == PdfViewerCursorMode.TextSelection)
+            {
+                HandleMouseDoubleClickForTextSelection(e);
+            }
+        }
+
+        private void HandleMouseDownForLinks(MouseEventArgs e)
+        {
             _dragState = null;
 
             if (_cachedLink != null)
@@ -754,12 +955,8 @@ namespace PdfiumViewer
             }
         }
 
-        /// <summary>Raises the <see cref="E:System.Windows.Forms.Control.MouseUp" /> event.</summary>
-        /// <param name="e">A <see cref="T:System.Windows.Forms.MouseEventArgs" /> that contains the event data. </param>
-        protected override void OnMouseUp(MouseEventArgs e)
+        private void HandleMouseUpForLinks(MouseEventArgs e)
         {
-            base.OnMouseUp(e);
-
             if (_dragState == null)
                 return;
 
@@ -801,6 +998,106 @@ namespace PdfiumViewer
                     // be thrown (when it auto-updates).
                 }
             }
+        }
+
+        private void HandleMouseDownForTextSelection(MouseEventArgs e)
+        {
+            if (e.Button != MouseButtons.Left)
+                return;
+
+            var pdfLocation = PointToPdf(e.Location);
+            if (!pdfLocation.IsValid)
+                return;
+
+            var characterIndex = Document.GetCharacterIndexAtPosition(pdfLocation, 4f, 4f);
+
+            if (characterIndex >= 0)
+            {
+                _textSelectionState = new TextSelectionState()
+                {
+                    StartPage = pdfLocation.Page,
+                    StartIndex = characterIndex,
+                    EndPage = -1,
+                    EndIndex = -1
+                };
+                _isSelectingText = true;
+                Capture = true;
+            }
+            else
+            {
+                _isSelectingText = false;
+                Capture = false;
+                _textSelectionState = null;
+            }
+        }
+
+        private void HandleMouseUpForTextSelection(MouseEventArgs e)
+        {
+            if (e.Button != MouseButtons.Left)
+                return;
+
+            _isSelectingText = false;
+            Capture = false;
+            Invalidate();
+        }
+
+        private void HandleMouseMoveForTextSelection(MouseEventArgs e)
+        {
+            if (!_isSelectingText)
+                return;
+
+            var mouseState = GetMouseState(e.Location);
+
+            if (mouseState.CharacterIndex >= 0)
+            {
+                _textSelectionState.EndPage = mouseState.PdfLocation.Page;
+                _textSelectionState.EndIndex = mouseState.CharacterIndex;
+
+                Invalidate();
+            }
+        }
+
+        private void HandleMouseDoubleClickForTextSelection(MouseEventArgs e)
+        {
+            var pdfLocation = PointToPdf(e.Location);
+            if (!pdfLocation.IsValid)
+                return;
+
+            if (Document.GetWordAtPosition(pdfLocation, 4f, 4f, out var word))
+            {
+                _textSelectionState = new TextSelectionState()
+                {
+                    StartPage = pdfLocation.Page,
+                    EndPage = pdfLocation.Page,
+                    StartIndex = word.Offset,
+                    EndIndex = word.Offset + word.Length
+                };
+
+                Invalidate();
+            }
+        }
+
+        private MouseState GetMouseState(Point mouseLocation)
+        {
+            // OnMouseMove and OnSetCursor get invoked a lot, often multiple times in succession for the same point.
+            // By just caching the mouse state for the last known position we can save a lot of work.
+
+            var currentState = _cachedMouseState;
+            if (currentState?.MouseLocation == mouseLocation)
+                return currentState;
+
+            _cachedMouseState = new MouseState()
+            {
+                MouseLocation = mouseLocation,
+                PdfLocation = PointToPdf(mouseLocation)
+            };
+
+            if (!_cachedMouseState.PdfLocation.IsValid)
+                return _cachedMouseState;
+
+            _cachedMouseState.CharacterIndex = Document.GetCharacterIndexAtPosition(_cachedMouseState.PdfLocation, 4f, 4f);
+
+            return _cachedMouseState;
         }
 
         /// <summary>
@@ -1040,6 +1337,44 @@ namespace PdfiumViewer
         {
             public PdfPageLink Link { get; set; }
             public Point Location { get; set; }
+        }
+
+        private class MouseState
+        {
+            public Point MouseLocation { get; set; }
+            public PdfPoint PdfLocation { get; set; }
+            public int CharacterIndex { get; set; }
+        }
+
+        private class TextSelectionState
+        {
+            public int StartPage { get; set; }
+            public int StartIndex { get; set; }
+            public int EndPage { get; set; }
+            public int EndIndex { get; set; }
+
+            public TextSelectionState GetNormalized()
+            {
+                if (EndPage < 0 || EndIndex < 0) // Special case when only start position is known
+                    return this;
+
+                if (EndPage < StartPage ||
+                    (StartPage == EndPage && EndIndex < StartIndex))
+                {
+                    // End position is before start position.
+                    // Swap positions so start is always before end.
+
+                    return new TextSelectionState()
+                    {
+                        StartPage = EndPage,
+                        StartIndex = EndIndex,
+                        EndPage = StartPage,
+                        EndIndex = StartIndex
+                    };
+                }
+
+                return this;
+            }
         }
     }
 }

--- a/PdfiumViewer/PdfViewer.resx
+++ b/PdfiumViewer/PdfViewer.resx
@@ -205,7 +205,7 @@
     <value>_bookmarks</value>
   </data>
   <data name="&gt;&gt;_bookmarks.Type" xml:space="preserve">
-    <value>PdfiumViewer.NativeTreeView, PdfiumViewer, Version=2.9.0.0, Culture=neutral, PublicKeyToken=91e4789cfb0609e0</value>
+    <value>PdfiumViewer.NativeTreeView, PdfiumViewer, Version=2.13.0.0, Culture=neutral, PublicKeyToken=91e4789cfb0609e0</value>
   </data>
   <data name="&gt;&gt;_bookmarks.Parent" xml:space="preserve">
     <value>_container.Panel1</value>
@@ -244,7 +244,7 @@
     <value>_renderer</value>
   </data>
   <data name="&gt;&gt;_renderer.Type" xml:space="preserve">
-    <value>PdfiumViewer.PdfRenderer, PdfiumViewer, Version=2.9.0.0, Culture=neutral, PublicKeyToken=91e4789cfb0609e0</value>
+    <value>PdfiumViewer.PdfRenderer, PdfiumViewer, Version=2.13.0.0, Culture=neutral, PublicKeyToken=91e4789cfb0609e0</value>
   </data>
   <data name="&gt;&gt;_renderer.Parent" xml:space="preserve">
     <value>_container.Panel2</value>

--- a/PdfiumViewer/PdfViewerCursorMode.cs
+++ b/PdfiumViewer/PdfViewerCursorMode.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace PdfiumViewer
+{
+    public enum PdfViewerCursorMode
+    {
+        Pan,
+        TextSelection
+    }
+}

--- a/PdfiumViewer/PdfiumViewer.csproj
+++ b/PdfiumViewer/PdfiumViewer.csproj
@@ -84,6 +84,7 @@
     <Compile Include="PdfInformation.cs" />
     <Compile Include="PdfSearchManager.cs" />
     <Compile Include="PdfTextSpan.cs" />
+    <Compile Include="PdfViewerCursorMode.cs" />
     <Compile Include="StreamManager.cs" />
     <Compile Include="PdfPageLink.cs" />
     <Compile Include="PdfPageLinks.cs" />


### PR DESCRIPTION
Support selecting and copying text using the mouse cursor. PdfRenderer has a new CursorMode property to control whether to use panning or text selection.

PdfiumViewer.Demo contains a sample implementation of a right click menu. This is not implemented in PdfViewer / PdfRenderer because of localization, but it's easy to add.

PdfFile now caches the PageData for the current page so it doesn't have to reload and destroy the page data on every mouse move.