### PR TITLE
Pdfium API removed FPDFDest_GetPageIndex

### DIFF
--- a/PdfiumViewer/NativeMethods.Pdfium.cs
+++ b/PdfiumViewer/NativeMethods.Pdfium.cs
@@ -330,11 +330,11 @@ namespace PdfiumViewer
             }
         }
 
-        public static uint FPDFDest_GetPageIndex(IntPtr document, IntPtr dest)
+        public static uint FPDFDest_GetDestPageIndex(IntPtr document, IntPtr dest)
         {
             lock (LockString)
             {
-                return Imports.FPDFDest_GetPageIndex(document, dest);
+                return Imports.FPDFDest_GetDestPageIndex(document, dest);
             }
         }
 
@@ -712,7 +712,7 @@ namespace PdfiumViewer
             public static extern IntPtr FPDFLink_GetDest(IntPtr document, IntPtr link);
 
             [DllImport("pdfium.dll")]
-            public static extern uint FPDFDest_GetPageIndex(IntPtr document, IntPtr dest);
+            public static extern uint FPDFDest_GetDestPageIndex(IntPtr document, IntPtr dest);
 
             [DllImport("pdfium.dll")]
             public static extern bool FPDFLink_GetAnnotRect(IntPtr linkAnnot, FS_RECTF rect);

--- a/PdfiumViewer/PdfFile.cs
+++ b/PdfiumViewer/PdfFile.cs
@@ -91,7 +91,7 @@ namespace PdfiumViewer
                     string uri = null;
 
                     if (destination != IntPtr.Zero)
-                        target = (int)NativeMethods.FPDFDest_GetPageIndex(_document, destination);
+                        target = (int)NativeMethods.FPDFDest_GetDestPageIndex(_document, destination);
 
                     var action = NativeMethods.FPDFLink_GetAction(annotation);
                     if (action != IntPtr.Zero)
@@ -227,7 +227,7 @@ namespace PdfiumViewer
         {
             IntPtr dest = NativeMethods.FPDF_BookmarkGetDest(_document, bookmark);
             if (dest != IntPtr.Zero)
-                return NativeMethods.FPDFDest_GetPageIndex(_document, dest);
+                return NativeMethods.FPDFDest_GetDestPageIndex(_document, dest);
 
             return 0;
         }


### PR DESCRIPTION
Changes on 8/23/18 at https://pdfium.googlesource.com/pdfium/+/e919ec18fc0b008241e5e5371d5762e9fe89de6f state FPDFDest_GetDestPageIndex is to be used instead of FPDFDest_GetPageIndex