### PR TITLE
Fixed the blank space at the end of PDF file which has 1500 pages.

### DIFF
--- a/PdfiumViewer/PdfRenderer.cs
+++ b/PdfiumViewer/PdfRenderer.cs
@@ -14,7 +14,6 @@ namespace PdfiumViewer
     {
         private static readonly Padding PageMargin = new Padding(4);
 
-        private int _height;
         private int _maxWidth;
         private int _maxHeight;
         private double _documentScaleFactor;
@@ -404,14 +403,12 @@ namespace PdfiumViewer
 
         private void ReloadDocument()
         {
-            _height = 0;
             _maxWidth = 0;
             _maxHeight = 0;
 
             foreach (var size in Document.PageSizes)
             {
                 var translated = TranslateSize(size);
-                _height += (int)translated.Height;
                 _maxWidth = Math.Max((int)translated.Width, _maxWidth);
                 _maxHeight = Math.Max((int)translated.Height, _maxHeight);
             }
@@ -678,7 +675,14 @@ namespace PdfiumViewer
         /// <returns>The document bounds.</returns>
         protected override Rectangle GetDocumentBounds()
         {
-            int height = (int)(_height * _scaleFactor + (ShadeBorder.Size.Vertical + PageMargin.Vertical) * Document.PageCount);
+            int scaledHeight = 0;
+            for (int page = 0; page < Document.PageSizes.Count; page++)
+            {
+                var size = TranslateSize(Document.PageSizes[page]);
+                scaledHeight += (int)(size.Height * _scaleFactor);
+            }
+
+            int height = (int)(scaledHeight + (ShadeBorder.Size.Vertical + PageMargin.Vertical) * Document.PageCount);
             int width = (int)(_maxWidth * _scaleFactor + ShadeBorder.Size.Horizontal + PageMargin.Horizontal);
             
             var center = new Point(


### PR DESCRIPTION
Maybe issue#179
If you use the scroll bar to move the long page PDF to the end, a blank will appear at the end.
This occurs when PdfDocuments.PageSizes[].Size contains a decimal point.

I have other fixes, so I'm glad if you merge.
I'm not used to git or github, so I'm sorry if it's a strange pull request.